### PR TITLE
fix: escape newline characters in CSV export (#65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FormVox will be documented in this file.
 
+## [1.1.5] - 2026-04-28
+
+### Fixed
+- **CSV export breaks when answers contain newline characters** — Long-text answers with embedded newlines (`\n`) are now exported with the literal two-character sequence `\n` instead of actual line-feed characters. RFC 4180 permits newlines inside quoted fields, but spreadsheet applications (Excel, LibreOffice Calc) often misinterpret them as row separators, splitting a single response across multiple rows. ([#65](https://github.com/nextcloud/formvox/issues/65))
+
 ## [1.1.4] - 2026-04-24
 
 ### Fixed

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -358,7 +358,7 @@ class ResponseService
                         }
                     }
                 }
-                $row[] = $answer;
+                $row[] = is_string($answer) ? $this->sanitizeCsvValue($answer) : $answer;
             }
 
             fputcsv($output, $row);
@@ -702,6 +702,21 @@ class ResponseService
             'min' => min($values),
             'max' => max($values),
         ];
+    }
+
+    /**
+     * Escape newline characters in a CSV field value.
+     *
+     * RFC 4180 permits newlines inside quoted fields, but spreadsheet
+     * applications such as Microsoft Excel misinterpret embedded newlines as
+     * row separators even when the value is correctly enclosed in double-quotes.
+     * Replacing them with the two-character literal sequence "\n" keeps every
+     * response on a single row while still conveying that a line break was
+     * present in the original answer.
+     */
+    private function sanitizeCsvValue(string $value): string
+    {
+        return str_replace(["\r\n", "\r", "\n"], '\n', $value);
     }
 
     /**


### PR DESCRIPTION
Long-text answers containing \n or \r\n characters were written as literal line-feeds into the CSV stream. PHP's fputcsv() correctly wraps such values in double-quotes per RFC 4180, but Microsoft Excel and several other spreadsheet applications still misinterpret embedded newlines as row separators, splitting a single response across multiple rows and corrupting the table structure.

Fix: introduce a private sanitizeCsvValue() helper that replaces all newline variants (\r\n, \r, \n) with the two-character literal sequence \n before the value is handed to fputcsv(). This keeps every response on a single row while still conveying to the reader that a line break was present in the original answer.

Affected method: ResponseService::exportCsv()
Reported by: argonimos (Apache / MySQL / PHP 8.3.30 / NC 33.0.0)

Closes #65