### PR TITLE
feat: render markdown in form-level description (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FormVox will be documented in this file.
 
+## [1.1.5] - 2026-04-28
+
+### Added
+- **Markdown support in form descriptions** — The form-level description field now renders markdown (bold, italic, links, lists, inline code, etc.) just as question and section descriptions already did. The form card preview in the dashboard strips markdown syntax before truncating, so it always shows clean plain text. ([#63](https://github.com/nextcloud/formvox/issues/63))
+
 ## [1.1.4] - 2026-04-24
 
 ### Fixed

--- a/src/components/FormCard.vue
+++ b/src/components/FormCard.vue
@@ -88,10 +88,27 @@ export default {
 			return null
 		})
 
+		const stripMarkdown = (text) => {
+			if (!text) return ''
+			return text
+				.replace(/!\[([^\]]*)\]\([^)]+\)/g, '$1')
+				.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+				.replace(/(\*\*|__)(.*?)\1/gs, '$2')
+				.replace(/(\*|_)(.*?)\1/gs, '$2')
+				.replace(/~~(.*?)~~/gs, '$1')
+				.replace(/`{1,3}[^`]*`{1,3}/g, '')
+				.replace(/^#{1,6}\s+/gm, '')
+				.replace(/^[>\-*+]\s+/gm, '')
+				.replace(/^\d+\.\s+/gm, '')
+				.replace(/\n{2,}/g, ' ')
+				.trim()
+		}
+
 		const truncate = (text, length) => {
 			if (!text) return ''
-			if (text.length <= length) return text
-			return text.substring(0, length) + '...'
+			const plain = stripMarkdown(text)
+			if (plain.length <= length) return plain
+			return plain.substring(0, length) + '...'
 		}
 
 		const formatDate = (dateString) => {

--- a/src/views/Respond.vue
+++ b/src/views/Respond.vue
@@ -68,7 +68,7 @@
 
       <div class="form-header">
         <h1>{{ form.title }}</h1>
-        <p v-if="form.description" class="form-description">{{ form.description }}</p>
+        <div v-if="form.description" class="form-description" v-html="renderMarkdown(form.description)" />
       </div>
 
       <div
@@ -1143,6 +1143,22 @@ export default {
     color: var(--color-text-maxcontrast);
     font-size: 16px;
     margin: 0;
+
+    :deep(p) {
+      margin: 0 0 0.5em;
+      &:last-child { margin-bottom: 0; }
+    }
+    :deep(a) { color: var(--color-primary-element); }
+    :deep(ul), :deep(ol) {
+      padding-left: 1.5em;
+      margin: 0.25em 0;
+    }
+    :deep(code) {
+      font-family: monospace;
+      background: var(--color-background-dark);
+      padding: 1px 4px;
+      border-radius: 3px;
+    }
   }
 }
 


### PR DESCRIPTION
Form descriptions were rendered as plain text, while question descriptions and section descriptions already used markdown-it + DOMPurify to render rich formatting.

* `src/views/Respond.vue` — Changed the form description element from `<p>{{ form.description }}</p>` to `<div v-html="renderMarkdown(...)">`. The element type change is required because markdown-it wraps its output in` <p>` tags — nesting` <p>` inside `<p>` is invalid HTML. Added `:deep()` CSS rules so nested markdown elements (links, lists, inline code) inherit the correct colours and spacing. The` renderMarkdown()` function used is the exact same one already called for section descriptions (line 88), so security properties (html: false + DOMPurify) are unchanged.
* `src/components/FormCard.vue` — The admin dashboard card previews descriptions truncated to 60 chars. Added a `stripMarkdown()` helper so raw syntax like `**bold**` or `# Heading` is stripped to plain text before truncating, keeping the card preview tidy.

The renderMarkdown() function used here is the same one already called for section descriptions (Respond.vue:88), so security properties (markdown-it with html:false + DOMPurify sanitisation) are unchanged.

Reported by: argonimos (Nextcloud 33.0.0)

Closes #63