### PR TITLE
fix: showIf conditions never trigger on multiple-choice questions (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FormVox will be documented in this file.
 
+## [1.1.5] - 2026-04-29
+
+### Fixed
+- **Conditional logic never triggers on multiple-choice questions** — All `showIf` operators silently evaluated to `false` when the source question was a multiple-choice (checkbox) question, because answers for that question type are stored as a string array at runtime while every operator was written assuming a scalar string. `contains`/`notContains` now check `answer.includes(value)` for array answers, and `in`/`notIn` now check for any intersection between the selected options and the configured value list. Existing string/numeric behaviour is unchanged. Fixed in both the frontend evaluator (`Respond.vue`) and the backend server-side evaluator (`ResponseService.php`) so visibility and server-side validation stay in sync. ([#71](https://github.com/nextcloud/formvox/issues/71))
+
 ## [1.1.4] - 2026-04-24
 
 ### Fixed

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -580,8 +580,10 @@ class ResponseService
                 case 'notEquals':
                     return $answer !== $value;
                 case 'contains':
+                    if (is_array($answer)) return in_array($value, $answer, true);
                     return is_string($answer) && str_contains($answer, $value);
                 case 'notContains':
+                    if (is_array($answer)) return !in_array($value, $answer, true);
                     return !is_string($answer) || !str_contains($answer, $value);
                 case 'isEmpty':
                     return $answer === null || $answer === '' || $answer === [];
@@ -592,9 +594,11 @@ class ResponseService
                 case 'lessThan':
                     return is_numeric($answer) && $answer < $value;
                 case 'in':
-                    return is_array($value) && in_array($answer, $value);
+                    if (is_array($answer)) return is_array($value) && count(array_intersect($answer, $value)) > 0;
+                    return is_array($value) && in_array($answer, $value, true);
                 case 'notIn':
-                    return is_array($value) && !in_array($answer, $value);
+                    if (is_array($answer)) return !is_array($value) || count(array_intersect($answer, $value)) === 0;
+                    return !is_array($value) || !in_array($answer, $value, true);
             }
         }
 

--- a/src/views/Respond.vue
+++ b/src/views/Respond.vue
@@ -568,8 +568,10 @@ export default {
         case 'notEquals':
           return answer !== value;
         case 'contains':
+          if (Array.isArray(answer)) return answer.includes(value);
           return typeof answer === 'string' && answer.includes(value);
         case 'notContains':
+          if (Array.isArray(answer)) return !answer.includes(value);
           return typeof answer !== 'string' || !answer.includes(value);
         case 'isEmpty':
           return !answer || answer === '' || (Array.isArray(answer) && answer.length === 0);
@@ -584,8 +586,10 @@ export default {
           return condition.operator === 'greaterThan' ? a > b : a < b;
         }
         case 'in':
+          if (Array.isArray(answer)) return Array.isArray(value) && answer.some(a => value.includes(a));
           return Array.isArray(value) && value.includes(answer);
         case 'notIn':
+          if (Array.isArray(answer)) return !Array.isArray(value) || !answer.some(a => value.includes(a));
           return !Array.isArray(value) || !value.includes(answer);
         default:
           return true;


### PR DESCRIPTION
Multiple-choice (checkbox) questions store their selected options as a string array at runtime, but every operator in evaluateCondition() was written assuming a scalar string answer, so showIf conditions on those questions were permanently broken regardless of which operator was used:

  equals 'a'     -> ['a','b'] === 'a'                     // false
  contains 'a'   -> typeof ['a','b'] === 'string' && ...  // false (guards out)
  in ['a']       -> ['a'].includes(['a','b'])             // false (array as needle)

Fix: teach contains/notContains and in/notIn how to evaluate against an array answer before falling through to the existing scalar logic.

  contains: if answer is array -> answer.includes(value)
  in:       if answer is array -> any selected option appears in value list
            (intersection-based; mirrors how a user reads the operator when
             the answer itself is a set rather than a scalar)

Both evaluators are updated in lockstep so the live frontend visibility and the backend validation/webhook path stay consistent:
- src/views/Respond.vue              (Array.isArray + .includes / .some)
- lib/Service/ResponseService.php    (is_array + in_array strict /
                                      array_intersect)

Existing behaviour for text, longtext, choice, dropdown and numeric question types is unchanged — the array branch short-circuits first and the original scalar logic runs as a fallback.

Closes #71