### PR TITLE
fix: table CSV exports show column IDs instead of labels (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FormVox will be documented in this file.
 
+## [1.1.5] - 2026-04-29
+
+### Fixed
+- **CSV export of table-question answers shows internal column IDs** — Each row of a table answer was JSON-encoded as-is, so columns appeared as opaque keys like `col36d83f62` instead of the labels the form author typed. `exportCsv()` now resolves the column-ID → label map (mirroring the existing matrix handling) before serialising. ([#70](https://github.com/nextcloud/formvox/issues/70))
+
 ## [1.1.4] - 2026-04-24
 
 ### Fixed

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -331,6 +331,23 @@ class ResponseService
                         $parts[] = $rowLabel . ': ' . $colLabel;
                     }
                     $answer = implode(', ', $parts);
+                } elseif (($question['type'] ?? '') === 'table' && is_array($answer)) {
+                    // Table questions: replace per-row column IDs with their human-readable labels
+                    $colLabels = [];
+                    foreach ($question['columns'] ?? [] as $c) {
+                        $colLabels[$c['id']] = $c['label'] ?? $c['id'];
+                    }
+                    $relabeled = array_map(function ($row) use ($colLabels) {
+                        if (!is_array($row)) {
+                            return $row;
+                        }
+                        $new = [];
+                        foreach ($row as $colId => $value) {
+                            $new[$colLabels[$colId] ?? $colId] = $value;
+                        }
+                        return $new;
+                    }, $answer);
+                    $answer = json_encode($relabeled, JSON_UNESCAPED_UNICODE);
                 } else {
                     // Map option values to labels for choice/multiple/dropdown questions
                     $options = $question['options'] ?? [];


### PR DESCRIPTION
Each row of a table-question answer is stored as a {colId: value} map. exportCsv() previously fell through to the generic JSON serialiser (line 354) which emitted opaque internal keys, e.g.

  [{"col36d83f62":"answer 1","coleadaea23":"answer 2"}]

so anyone consuming the export had no way to tell which column was which without manually opening the form definition.

Fix: add an explicit table branch alongside the existing matrix branch in exportCsv(). It builds a colId -> label map from the question's columns array and rewrites every row's keys before json_encode(). The behaviour for matrix and all other question types is untouched.

Closes #70