### PR TITLE
fix: clear stale question settings when changing question type (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FormVox will be documented in this file.
 
+## [1.1.5] - 2026-04-29
+
+### Fixed
+- **Question settings leak across type changes** — Switching a question's type in the editor only initialised new fields, never cleared the old ones, so e.g. options arrays from a former `choice` question kept polluting validation and CSV export after the question was changed to `text`, and integer-only validation rules from a `text` question silently rejected valid input on a former `multiple` question. `onTypeChange()` now drops every type-specific field the new type doesn't use, with a special case for the matrix↔table `columns` transition where both types share the field name but the row shapes are incompatible. ([#69](https://github.com/nextcloud/formvox/issues/69))
+
 ## [1.1.4] - 2026-04-24
 
 ### Fixed

--- a/src/components/QuestionEditor.vue
+++ b/src/components/QuestionEditor.vue
@@ -844,7 +844,48 @@ export default {
       emit('update', JSON.parse(JSON.stringify(localQuestion)));
     };
 
+    // Type-specific fields kept on the question object for each question type.
+    // Anything in the union of all values that is NOT in the active type's list
+    // gets stripped on type change so stale settings (option lists, validation
+    // rules, columns with the wrong shape, etc.) don't leak between types.
+    const TYPE_FIELDS = {
+      text:     ['validation'],
+      textarea: ['validation'],
+      number:   ['validation'],
+      choice:   ['options'],
+      multiple: ['options'],
+      dropdown: ['options'],
+      date:     ['dateMin', 'dateMax'],
+      datetime: ['dateMin', 'dateMax'],
+      time:     ['timeMin', 'timeMax'],
+      scale:    ['scaleMin', 'scaleMax'],
+      rating:   ['ratingMax'],
+      matrix:   ['rows', 'columns'],
+      table:    ['columns', 'minRows', 'maxRows'],
+      file:     ['allowedTypePreset', 'allowedTypes', 'maxFileSize', 'maxFiles'],
+    };
+    const ALL_TYPE_SPECIFIC_FIELDS = [...new Set(Object.values(TYPE_FIELDS).flat())];
+
     const onTypeChange = () => {
+      // Drop every type-specific field the new type does not use.
+      const keep = TYPE_FIELDS[localQuestion.type] || [];
+      ALL_TYPE_SPECIFIC_FIELDS.forEach(field => {
+        if (!keep.includes(field)) delete localQuestion[field];
+      });
+
+      // matrix.columns and table.columns are both kept by name, but their row shapes
+      // are incompatible (matrix: {id,label,value}; table: {id,label,inputType,...}).
+      // If the existing array doesn't match the shape the new type expects, drop it
+      // so the initialiser below can build a fresh one.
+      const firstCol = localQuestion.columns?.[0];
+      if (firstCol) {
+        const isTableShape = 'inputType' in firstCol;
+        if ((localQuestion.type === 'table' && !isTableShape)
+            || (localQuestion.type === 'matrix' && isTableShape)) {
+          delete localQuestion.columns;
+        }
+      }
+
       // Initialize type-specific properties
       if (hasOptions.value && (!localQuestion.options || localQuestion.options.length === 0)) {
         const id1 = `opt${uuidv4().split('-')[0]}`;


### PR DESCRIPTION
QuestionEditor.onTypeChange() previously only INITIALISED type-specific fields the new type needed; it never DELETED fields belonging to the old type. As a result a question kept settings that no longer applied:

- Options arrays from a former choice/multiple/dropdown question kept showing up in validateAnswers() and CSV export after the question was changed to text or number.
- Integer-only validation rules from a former text question silently rejected valid input after the question was changed to multiple.
- matrix.columns and table.columns share a field name but have incompatible row shapes ({id,label,value} vs {id,label,inputType,options,optionsText}), so switching between matrix and table left a half-broken array.

Fix: introduce a TYPE_FIELDS map describing which type-specific fields belong to each type. On every change we drop every type-specific field the new type doesn't use, then let the existing per-type initialiser seed defaults for whatever the new type does need. The matrix <-> table columns transition is handled explicitly via row-shape detection so the column array is rebuilt with the right shape.

Common fields (id, type, question, description, required, showIf, sectionId, color) are never touched.

Closes #69