### PR TITLE
fix: forms in team folders return "Form not found" on public link (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to FormVox will be documented in this file.
 
+## [1.1.5] - 2026-04-29
+
+### Fixed
+- **Forms in team folders return "Form not found" on the public share link** — `FormService::getFileByIdPublic` recognised the team-folder storage prefixes added in 1.0.1 but threw `NotFoundException` immediately if `findUserWithGroupFolderAccess` could not resolve a user via the `group_folders_groups` table — even though the generic Case 3 mounts-table fallback right below would have located the same file. The team-folder branch now falls through to that fallback instead of bailing out, so forms remain reachable when access is granted via Circles, individual user assignment, or any other mechanism the `group_folders_groups` table does not record. ([#68](https://github.com/nextcloud/formvox/issues/68))
+
 ## [1.1.4] - 2026-04-24
 
 ### Fixed

--- a/lib/Service/FormService.php
+++ b/lib/Service/FormService.php
@@ -562,9 +562,14 @@ class FormService
             throw new NotFoundException('Form not found');
         }
 
-        // Case 2: Group folder / Team folder
+        // Case 2: Group folder / Team folder (fast path)
         //   - Local:         local::.../__groupfolders/{id}/
         //   - Object store:  object::groupfolder:{id}.{objectstore_id}
+        // If the regex matches and we can resolve a user via the group_folders_groups
+        // table, return immediately. Otherwise fall through to Case 3, since some
+        // team-folder deployments grant access via mechanisms (Circles, direct user
+        // assignment) that group_folders_groups does not capture, and a different
+        // storage-id format may yet appear in future Nextcloud releases.
         if (
             preg_match('#__groupfolders/(\d+)/#', $storageId, $matches)
             || preg_match('#^object::groupfolder:(\d+)#', $storageId, $matches)
@@ -580,10 +585,12 @@ class FormService
                     return $nodes[0];
                 }
             }
-            throw new NotFoundException('Form not found');
+            // fall through to Case 3
         }
 
-        // Case 3: External storage (SMB, SFTP, S3, local mounts, etc.)
+        // Case 3: Generic fallback — find any user who has the storage mounted.
+        // Works for external storage (SMB, SFTP, S3, local mounts) and for any
+        // group/team folder whose access mechanism Case 2 could not resolve.
         $userId = $this->findUserWithStorage((int)$row['numeric_id']);
         if ($userId !== null) {
             $userFolder = $this->rootFolder->getUserFolder($userId);


### PR DESCRIPTION
The team-folder fix shipped in 1.0.1 wired up two storage-id patterns (__groupfolders/{id}/ and object::groupfolder:{id}) in FormService::getFileByIdPublic, but if findUserWithGroupFolderAccess returned null for any reason the function threw NotFoundException immediately — even though the generic Case 3 mounts-table fallback right below would have located the same file via any user that has the storage mounted.

In practice the group_folders_groups table is not the only path by which a team folder can be reached: the access can be granted via Circles, direct user assignment, or future Nextcloud permission mechanisms that simply do not produce a row in that table. In any of those cases the previous code short-circuited and the share link rendered the generic "Form not found" page even for a freshly created form whose .fvform file was readable on disk.

Fix: when Case 2 cannot resolve a user, fall through to Case 3 instead of throwing. Case 3 queries the mounts table directly, which works for any storage type a user has mounted, including team folders that bypass group_folders_groups.

The fast-path is preserved (matching team-folder storage IDs still hit Case 2 first), so this is a strict superset of the previous behaviour.

Closes #68