### PR TITLE
Fix max score calulation for multiple choice questions

### DIFF
--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -788,13 +788,13 @@ class ResponseService
 
             foreach ($question['options'] as $option) {
                 $optionScore = $option['score'] ?? 0;
-                $questionMaxScore = max($questionMaxScore, $optionScore);
-
                 if ($question['type'] === 'multiple') {
+                    $questionMaxScore += max($optionScore, 0);
                     if (is_array($answer) && in_array($option['value'], $answer)) {
                         $questionScore += $optionScore;
                     }
                 } else {
+                    $questionMaxScore = max($questionMaxScore, $optionScore);
                     if ($answer === $option['value']) {
                         $questionScore = $optionScore;
                     }

--- a/lib/Service/ResponseService.php
+++ b/lib/Service/ResponseService.php
@@ -789,7 +789,7 @@ class ResponseService
             foreach ($question['options'] as $option) {
                 $optionScore = $option['score'] ?? 0;
                 if ($question['type'] === 'multiple') {
-                    $questionMaxScore += max($optionScore, 0);
+                    $questionMaxScore += $optionScore;
                     if (is_array($answer) && in_array($option['value'], $answer)) {
                         $questionScore += $optionScore;
                     }


### PR DESCRIPTION
Hey,

I noticed a bug where quizzes with multiple-choice answers can produce a score over 100%. The issue is that the max score for multiple-choice questions is calculated using `max(...)` (taking only the single highest option), instead of summing all positive-scoring options. 