### PR TITLE
fix: truncate filenames by UTF-8 characters

### DIFF
--- a/lib/Service/FormService.php
+++ b/lib/Service/FormService.php
@@ -1476,7 +1476,7 @@ class FormService
         // Lowercase
         $name = strtolower($name);
         // Limit length
-        $name = substr($name, 0, 50);
+        $name = mb_substr($name, 0, 50, 'UTF-8');
         // Default if empty
         if (empty($name)) {
             $name = 'form';


### PR DESCRIPTION
## Summary

- Root cause: `substr()` truncates by bytes, which can split multibyte UTF-8 filenames.
- Fix: use `mb_substr($name, 0, 50, 'UTF-8')` to truncate by UTF-8 characters.

## Verification

- Deterministic UTF-8 regression check: passed.
- `php -l lib/Service/FormService.php`: passed.
- `git diff --check`: passed.
- Independent exact-SHA review: approved.

## Production evidence

After deployment of this exact candidate, live create/read/delete with a long Korean title passed, and a real 46-question form was created and read successfully.

No secrets or credentials are included.